### PR TITLE
Add authentication bypass feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,14 @@ import spotipy
 import typer
 from spotipy.oauth2 import SpotifyClientCredentials
 from dataframe import create_dataframe
+from skip_auth import access_token
 
-spotify = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials())
+# Doesn't allow personal features such as playlist access, 
+# but removes the need for username/password.
+# Could be a launch option in the future?
+spotify = spotipy.Spotify(auth=skip_auth.access_token()) 
+
+#spotify = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials())
 app = typer.Typer()
 
 

--- a/skip_auth.py
+++ b/skip_auth.py
@@ -1,0 +1,11 @@
+from requests import get
+from re import search
+from json import loads
+
+def access_token():
+    response = get("https://open.spotify.com/search")
+    match = search('<script id="session" data-testid="session" type="application/json">({.*})</script>', response.text)
+    json_data = loads(match.group(1))
+    access_token = json_data.get('accessToken')
+    return access_token
+


### PR DESCRIPTION
This is both a convenience option for developing and a possible feature for when we demo/distribute. This allows an "anonymous" authentication with the Spotify API, so we have full access to search, but obviously no access to user data like playlists since we haven't really logged in.

I'm setting it as the default, but this could be a launch option in the future depending on what other features we add.