### PR TITLE
Changes to pkce auth to save client ID

### DIFF
--- a/pkce.py
+++ b/pkce.py
@@ -1,8 +1,19 @@
+import json
 from requests import Session
 from spotipy import Spotify, SpotifyPKCE
 
-client_id = "52bd7638025f4ce088463655b18efc50"  # no need to replace this with your own client_id
-redirect_uri = "http://localhost:8888/callback/"  # same for this one
+#Try to load the client_id from the JSON file
+try:
+    with open('client_id.json', 'r') as f:
+        client_id = json.load(f)
+except FileNotFoundError:
+    #If the file doesn't exist, prompt the user to enter their client_id
+    client_id = input("Please enter your client_id: ")
+    #Save the client_id to the JSON file
+    with open('client_id.json', 'w') as f:
+        json.dump(client_id, f)
+
+redirect_uri = "http://localhost:8888/callback/"
 scope = "user-library-read user-top-read playlist-modify-public playlist-modify-private"
 state = None
 
@@ -11,6 +22,5 @@ spotify = Spotify(auth_manager=SpotifyPKCE(client_id, redirect_uri, state, scope
 def fixed_del(self):
     if isinstance(self._session, Session):
         self._session.close()
-
 
 spotify.__del__ = fixed_del.__get__(spotify, Spotify)


### PR DESCRIPTION
Issue where user could not run without their own client ID. This issue still persists but allows user to input their ID via command line.